### PR TITLE
fix: Specify Paper API version

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ version: @version@
 main: click.seichi.eategg.EatEgg
 depend:
   - WorldGuard
+api-version: 1.18
 commands:
   eategg:
     usage: /eategg <toggle|reload>


### PR DESCRIPTION
The api-version required to use the Paper API is not specified and an error occurs when loading.